### PR TITLE
Enhance getHandleDelete for metadata and error handling

### DIFF
--- a/src/handleDelete.ts
+++ b/src/handleDelete.ts
@@ -10,15 +10,45 @@ interface Args {
 
 export const getHandleDelete =
   ({ cloudinary, folder }: Args): HandleDelete =>
-  async ({ filename }) => {
+  async ({ filename, doc }) => {
     const filePath = path.posix.join(folder, filename)
 
     try {
       // Extract public_id without file extension
-      const publicId = filePath.replace(/\.[^/.]+$/, '')
-      await cloudinary.uploader.destroy(publicId)
+      let publicId = filePath.replace(/\.[^/.]+$/, '')
+      
+      // Try to get metadata from doc if available (from Cloudinary plugin)
+      let resourceType: string = 'image'
+      let deliveryType: string = 'upload'
+      
+      if (doc?.cloudinary) {
+        // Use stored Cloudinary metadata if available
+        publicId = doc.cloudinary.public_id || publicId
+        resourceType = doc.cloudinary.resource_type || resourceType
+        deliveryType = doc.cloudinary.type || deliveryType
+      }
+
+      // Attempt deletion with proper parameters
+      const result = await cloudinary.uploader.destroy(publicId, {
+        resource_type: resourceType,
+        type: deliveryType,
+        invalidate: true, // Invalidate CDN cache
+      })
+
+      // Log the result for debugging
+      const okResults = new Set(['ok', 'not found', 'already deleted'])
+      if (!okResults.has(result?.result)) {
+        console.warn(
+          `Cloudinary destroy returned unexpected result for ${publicId}:`,
+          result
+        )
+      } else {
+        console.log(`Successfully deleted ${publicId} from Cloudinary`)
+      }
+      
     } catch (error) {
       console.error('Error deleting file from Cloudinary:', error)
-      throw error
+      // Don't throw - allow the CMS deletion to proceed
+      // throw error
     }
   }


### PR DESCRIPTION
Modified the getHandleDelete function to accept a 'doc' parameter for enhanced metadata handling during file deletion from Cloudinary. Updated the deletion logic to utilize Cloudinary metadata if available and adjusted error handling to not throw an error during deletion.