### PR TITLE
feat: Add workflow to publish package to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,102 @@
+name: Publish Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version Bump Type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
+      prerelease_id:
+        description: "Prerelease ID (e.g. alpha, beta, rc). Only used for pre* version types."
+        required: false
+        default: "alpha"
+        type: string
+
+jobs:
+  publish:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Bump Version
+        id: version
+        run: |
+          VERSION_TYPE="${{ github.event.inputs.version_type }}"
+          PRERELEASE_ID="${{ github.event.inputs.prerelease_id }}"
+
+          if [[ "$VERSION_TYPE" == pre* ]]; then
+            npm version $VERSION_TYPE --preid=$PRERELEASE_ID --no-git-tag-version
+          else
+            npm version $VERSION_TYPE --no-git-tag-version
+          fi
+
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+          echo "::notice::Bumping version to $NEW_VERSION"
+
+      - name: Publish to NPM
+        run: |
+          VERSION_TYPE="${{ github.event.inputs.version_type }}"
+          PRERELEASE_ID="${{ github.event.inputs.prerelease_id }}"
+
+          # Determine tag
+          TAG="latest"
+          if [[ "$VERSION_TYPE" == pre* ]]; then
+            TAG="$PRERELEASE_ID"
+            # Fallback to 'next' if prerelease_id is empty, though 'alpha' is default
+            if [ -z "$TAG" ]; then TAG="next"; fi
+          fi
+
+          echo "Publishing with tag: $TAG"
+          npm publish --tag $TAG --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Commit and Push Changes
+        run: |
+          VERSION=${{ steps.version.outputs.new_version }}
+
+          git add package.json bun.lockb
+          git commit -m "chore(release): v$VERSION"
+
+          # Create and push tag
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin HEAD --tags


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates the process of publishing the package to NPM. The workflow allows for manual triggering with options to specify the version bump type and prerelease ID. It handles dependency installation, version bumping, and publishing with appropriate tags.