### PR TITLE
feat: Add GitHub release and changelog generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,6 +72,15 @@ jobs:
 
           echo "::notice::Bumping version to $NEW_VERSION"
 
+      - name: Generate Changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: "CHANGELOG.md"
+          skip-version-file: "true"
+          fallback-version: ${{ steps.version.outputs.new_version }}
+
       - name: Publish to NPM
         run: |
           VERSION_TYPE="${{ github.event.inputs.version_type }}"
@@ -94,7 +103,7 @@ jobs:
         run: |
           VERSION=${{ steps.version.outputs.new_version }}
 
-          git add package.json bun.lockb
+          git add package.json bun.lockb CHANGELOG.md
           git commit -m "chore(release): v$VERSION"
 
           # Create and push tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Build Project
+        run: bun run build
+
+      - name: Generate Changelog for Release Body
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-file: "false" # Don't write to file, just output to variable
+          skip-version-file: "true"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          files: |
+            dist/**/*
+            LICENSE
+            README.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a new GitHub Actions workflow that automatically generates a release and populates its body with a changelog when a new tag is pushed. Also updates the existing publish workflow to include the generated CHANGELOG.md in the commit.